### PR TITLE
fix leash anchor

### DIFF
--- a/visor-core/src/main/java/org/vmstudio/visor/mixin/client/renderer/entity/MobRendererMixin.java
+++ b/visor-core/src/main/java/org/vmstudio/visor/mixin/client/renderer/entity/MobRendererMixin.java
@@ -1,27 +1,41 @@
 package org.vmstudio.visor.mixin.client.renderer.entity;
 
-import org.vmstudio.visor.api.common.HandType;
-import org.vmstudio.visor.core.client.render.VRRenderState;
-import org.vmstudio.visor.core.client.render.helpers.RenderPoseHelper;
 import net.minecraft.client.renderer.entity.MobRenderer;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.phys.Vec3;
 import org.joml.Vector3f;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
-
+import org.vmstudio.visor.api.client.player.pose.PlayerPoseType;
+import org.vmstudio.visor.api.common.HandType;
+import org.vmstudio.visor.core.client.player.VRClientPlayers;
+import org.vmstudio.visor.core.client.render.VRRenderState;
 
 @Mixin(MobRenderer.class)
 public class MobRendererMixin {
-
     @Redirect(at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;getRopeHoldPosition(F)Lnet/minecraft/world/phys/Vec3;"), method = "renderLeash")
     public Vec3 visor$vrRenderLeash(Entity instance, float partialTick) {
         if (VRRenderState.getPhase().isNotVRWorld()) {
             return instance.getRopeHoldPosition(partialTick);
         }
-        return new Vec3((Vector3f) RenderPoseHelper.getHandPosition(
-                HandType.MAIN
-        ));
+
+        if (!(instance instanceof Player player)) {
+            return instance.getRopeHoldPosition(partialTick);
+        }
+
+        var vrPlayer = VRClientPlayers.getPlayer(player);
+        if (vrPlayer == null) {
+            return instance.getRopeHoldPosition(partialTick);
+        }
+
+        return new Vec3(
+                new Vector3f(
+                        vrPlayer.getPoseData(PlayerPoseType.RENDER)
+                                .getHand(HandType.MAIN)
+                                .getPosition()
+                )
+        );
     }
 }


### PR DESCRIPTION
## What changed

Fixed leash rendering in vr

Previously, the leash anchor position was always redirected with the VR hand position, which caused the leash to visually come from the player's main hand even when it was actually attached to an entity in world

<img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/e7c2d21a-957f-4f57-b634-698f3a966333" />

## How i fixed this
- the redirect is only applied when the leash holder is actually a player
- non-player leash holders keep the vanilla anchor position
- VR players use the VR main-hand pose, matching `getRopeHoldPosition()`
<img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/e937c8ed-187d-4749-83b6-72d7706ac7bd" />

## Main issue
The issue was in `MobRendererMixin`, which redirected `Entity#getRopeHoldPosition()` too broadly and always returned a VR hand position without checking what kind of entity was actually holding the leash