### PR TITLE
Fix VR item positioning and unify hand transform logic

### DIFF
--- a/visor-core/src/main/java/org/vmstudio/visor/core/client/render/decoration/hand/VRHandRenderer.java
+++ b/visor-core/src/main/java/org/vmstudio/visor/core/client/render/decoration/hand/VRHandRenderer.java
@@ -25,12 +25,15 @@ import org.vmstudio.visor.api.common.utils.VRMathUtils;
 import org.vmstudio.visor.compatibility.ShadersHelper;
 import org.vmstudio.visor.core.client.settings.VRClientSettings;
 import org.vmstudio.visor.core.client.settings.options.enums.MirrorMode;
+import org.vmstudio.visor.core.client.player.body.full.VRBodyTypeFull;
 import org.vmstudio.visor.core.client.utils.ModelUtils;
 import org.vmstudio.visor.extensions.client.render.GameRendererExtension;
 import org.vmstudio.visor.core.client.render.decoration.registry.VRHandEffectRegistry;
 import org.vmstudio.visor.core.client.render.decoration.registry.VRHandItemPoseRegistry;
+import org.vmstudio.visor.core.client.render.helpers.ItemHandTransformHelper;
 import org.vmstudio.visor.core.client.render.helpers.RenderHelper;
 import org.vmstudio.visor.core.client.render.helpers.RenderPoseHelper;
+import org.vmstudio.visor.core.client.render.player.model.ControllerSpaceItemAnchorModel;
 import org.vmstudio.visor.api.client.gui.helpers.TexturesHelper;
 import org.vmstudio.visor.core.client.render.VRRenderState;
 import org.vmstudio.visor.core.client.gui.VRCursorHandlerImpl;
@@ -56,7 +59,6 @@ import static org.vmstudio.visor.core.client.VisorClientImpl.MC;
 
 
 public class VRHandRenderer {
-
     private static final AtumColorImmutable GUI_HANDS_COLOR = new AtumColorImmutable(
             64, 64, 64,
             255
@@ -503,26 +505,13 @@ public class VRHandRenderer {
         }
 
 
-        float entityScale = 0.9375F;
-        float armsScale = VRClientSettings.getPlayerModelArmsScale();
+        float entityScale = getDecoratorItemBaseScale(player);
         poseStack.scale(entityScale, entityScale, entityScale);
 
         ModelUtils.controllerToModelOrientation(poseStack);
-
-        //match ItemInHandLayerMixin pose
-        poseStack.scale(armsScale, 1.0F, armsScale);
-        poseStack.translate(0.0F, 0.65F, 0.0F);
-        poseStack.scale(1.0F, armsScale, 1.0F);
-        poseStack.translate(0.0F, -0.65F, 0.0F);
+        applyControllerSpaceItemBaseline(player, humanoidarm, poseStack);
 
         boolean isLeftHand = humanoidarm == HumanoidArm.LEFT;
-        poseStack.mulPose(Axis.XP.rotationDegrees(-90.0F));
-        poseStack.mulPose(Axis.YP.rotationDegrees(180.0F));
-        poseStack.translate(
-                0,
-                0.125F,
-                0.125F
-        );
 
         HandType handType = mainHand ? HandType.MAIN : HandType.OFFHAND;
         applyItemHandPose(player, handType, itemStack, poseStack, equipProgress, pPartialTicks);
@@ -573,7 +562,8 @@ public class VRHandRenderer {
             applySwingPose(swingType, poseStack, humanoidArm, swingProgress);
         }
 
-        poseStack.scale(0.4f, 0.4F, 0.4F);
+        float handBaseScale = getDecoratorItemBaseScale(player);
+        poseStack.scale(handBaseScale, handBaseScale, handBaseScale);
         boolean slim = player.getModelName()
                 .equals("slim");
 
@@ -604,6 +594,51 @@ public class VRHandRenderer {
             );
         }
         poseStack.popPose();
+    }
+
+    private float getDecoratorItemBaseScale(AbstractClientPlayer player) {
+        return 0.9375F * ClientContext.localPlayer.getFullHeightScale();
+    }
+
+    private void applyControllerSpaceItemBaseline(AbstractClientPlayer player,
+                                                  HumanoidArm humanoidArm,
+                                                  PoseStack poseStack) {
+        ControllerSpaceItemAnchorModel anchorModel = resolveControllerSpaceAnchorModel(player);
+        if (anchorModel != null) {
+            anchorModel.applyLocalHandItemAnchor(humanoidArm, poseStack);
+            ItemHandTransformHelper.applyArmScaleCorrection(poseStack);
+            ItemHandTransformHelper.applyVanillaThirdPersonItemTransform(poseStack, humanoidArm);
+            return;
+        }
+
+        applyLegacyDecoratorItemBaseline(humanoidArm, poseStack);
+    }
+
+    private ControllerSpaceItemAnchorModel resolveControllerSpaceAnchorModel(AbstractClientPlayer player) {
+        boolean slim = "slim".equals(player.getModelName());
+        var bodyType = ClientContext.localPlayer.getBodyType();
+        if (!bodyType.isSelfModelVisible() && VRBodyTypeFull.getInstance() != null) {
+            bodyType = VRBodyTypeFull.getInstance();
+        }
+
+        var playerRenderer = bodyType.getRenderer().getModelRenderer(
+                ClientContext.localPlayer,
+                slim ? VRBodyRenderer.MODEL_NAME_SLIM : VRBodyRenderer.MODEL_NAME_DEFAULT
+        );
+        var model = playerRenderer.getModel();
+        if (model instanceof ControllerSpaceItemAnchorModel anchorModel) {
+            return anchorModel;
+        }
+        return null;
+    }
+
+    private void applyLegacyDecoratorItemBaseline(HumanoidArm humanoidArm, PoseStack poseStack) {
+        float armsScale = VRClientSettings.getPlayerModelArmsScale();
+        poseStack.scale(armsScale, 1.0F, armsScale);
+        ItemHandTransformHelper.applyArmScaleCorrection(poseStack);
+        poseStack.mulPose(Axis.XP.rotationDegrees(-90.0F));
+        poseStack.mulPose(Axis.YP.rotationDegrees(180.0F));
+        poseStack.translate(0.0F, 0.125F, 0.625F);
     }
 
     @Unique

--- a/visor-core/src/main/java/org/vmstudio/visor/core/client/render/decoration/hand/VRItemPoseDefault.java
+++ b/visor-core/src/main/java/org/vmstudio/visor/core/client/render/decoration/hand/VRItemPoseDefault.java
@@ -47,14 +47,15 @@ public class VRItemPoseDefault extends VRHandItemPose {
         InteractionHand mcHand = hand == HandType.MAIN ? InteractionHand.MAIN_HAND : InteractionHand.OFF_HAND;
         int handDir = hand == HandType.MAIN ? 1 : -1;
 
-
         PoseParams params = computeParams(item, player, mcHand, handDir, equipProgress, partialTicks);
-
-
-
+        stack.mulPose(params.preRotation);
+        stack.translate(params.offsetX, params.offsetY, params.offsetZ);
+        stack.mulPose(params.rotation);
+        stack.scale(params.scale, params.scale, params.scale);
     }
 
 
+    // ref: 0.3.0-snapshot-6 version: https://github.com/VisorModStudio/Visor/blob/ab99917d6d6a88b67aad4edc01383a7d260d1012/visor-core/src/main/java/org/vmstudio/visor/core/client/render/decoration/hand/VRItemPoseDefault.java#L62
     private PoseParams computeParams(ItemStack item,
                                      AbstractClientPlayer player,
                                      InteractionHand mcHand,
@@ -64,20 +65,148 @@ public class VRItemPoseDefault extends VRHandItemPose {
         float gunAngle = ClientContext.rawPoseHandler.getGunAngle();
         HandType handType = HandType.fromMc(mcHand);
         // defaults
-        float scale = 0.6f;
-        float translateX = 0, translateY = 0.005f, translateZ = 0f;
+        float scale = 0.7f;
+        float translateX = 0.0f, translateY = 0.005f, translateZ = 0f;
         Quaternionf preRotation = Axis.YP.rotationDegrees(0);
-        Quaternionf rotation = Axis.XP.rotationDegrees(0);
+        Quaternionf rotation = Axis.XP.rotationDegrees(-110 + gunAngle);
 
         var transformType = getTransformType(item, player, MC.getItemRenderer());
         switch (transformType) {
             case BLOCK_ITEM, DEFAULT -> {
-                translateZ -= 0.08f;
-                scale = 0.3f;
+                if (item.getItem() instanceof ArrowItem) {
+                    preRotation = Axis.ZP.rotationDegrees(-180);
+                    rotation = Axis.XP.rotationDegrees(-gunAngle);
+                } else {
+                    rotation = Axis.ZP.rotationDegrees(180);
+                    rotation.mul(Axis.XP.rotationDegrees(-135));
+                    rotation.mul(Axis.YP.rotationDegrees(90));
+                    translateX += 0.04f;
+                    translateZ -= 0.12f;
+                }
             }
             case BLOCK_3D -> {
                 translateZ -= 0.1f;
-                scale = 0.3f;
+            }
+            // a one-size-fits-all solution, lol
+            case CONSUMABLE, COMPASS, BLOCK_STICK, HORN, TOOL -> {
+                long ticks = player.getUseItemRemainingTicks();
+                rotation = Axis.ZP.rotationDegrees(180);
+                rotation.mul(Axis.XP.rotationDegrees(-135));
+                translateZ += 0.006f * Mth.sin(ticks) + 0.02f;
+//                translateX += 0.08f;
+//                scale = 0.4f;
+            }
+            case MAP -> {
+                preRotation = Axis.YP.rotationDegrees(0);
+                rotation = Axis.XP.rotationDegrees(-45);
+                translateX = 0;
+                translateY = 0.16f;
+                translateZ = -0.075f;
+                scale = 0.75f;
+            }
+            case FISHING_ROD -> {
+//                translateX += 0.05f;
+                translateY += -0.18f + gunAngle / 40 * 0.1f;
+                translateZ -= 0.10f;
+                rotation.mul(Axis.XP.rotationDegrees(40));
+                scale = 0.8f;
+            }
+            // FIXME(!!): crossbow have shadow-issue with XP rotation
+            case CROSSBOW -> {
+                rotation = Axis.YP.rotationDegrees(-10.0F);
+//                rotation.mul(Axis.XP.rotationDegrees(-12.0F));
+//                rotation = Axis.XP.rotationDegrees(-55.0F + gunAngle);
+//                translateX -= handDir * 0.05f;
+
+                translateX += 0.04f;
+                translateZ += 0.08f;
+                translateY += 0.04f;
+            }
+            case BOW -> {
+                rotation.mul(Axis.XP.rotationDegrees(90.0F - gunAngle));
+                rotation.mul(Axis.ZP.rotationDegrees(handDir == 1 ? -10.0F : 10.0F));
+                translateZ -= 0.06F;
+                translateX += 0.04F;
+//                translateY += -0.1F;
+//                translateZ += 0.1F;
+            }
+            case SWORD -> {
+                rotation.mul(Axis.XP.rotationDegrees(45.0f));
+                translateZ -= 0.08F;
+                translateY -= 0.01f;
+            }
+            case SHIELD -> {
+                if (ClientContext.localPlayer.isLeftHanded()) handDir *= -1;
+                translateY -= 0.04f;
+                translateZ += 0.1f;
+                rotation.mul(Axis.XP.rotationDegrees((handDir == 1 ? 105 : 115) - gunAngle));
+                translateX += handDir == 1 ? 0.015f : -0.015f;
+
+                // FIXME(!!): shield doesn't have interaction animation
+//                if (player.isUsingItem() && player.getUsedItemHand() == mcHand) {
+//                    rotation.mul(Axis.XP.rotationDegrees(handDir * 5));
+//                    rotation.mul(Axis.ZP.rotationDegrees(-5));
+//                    translateY -= 0.12f;
+//                    translateZ -= handDir == 1 ? 0.1f : 0.11f;
+//                    translateX += handDir == 1 ? 0.04f : 0.19f;
+//                    rotation.mul(Axis.YP.rotationDegrees(handDir * (player.isBlocking() ? 90 : (1 - equipProgress) * 90)));
+//                }
+                rotation.mul(Axis.YP.rotationDegrees((float) handDir * 0));
+            }
+            case SPEAR -> {
+                rotation.identity();
+//                translateX -= 0.135F;
+                translateZ += 0.645F;
+
+                float progress = 0.0F;
+                boolean charging = false;
+                int riptideLevel = 0;
+
+                // FIXME(!!): spear have BAD interaction animation
+                if (player.isUsingItem()
+                        && player.getUseItemRemainingTicks() > 0
+                        && player.getUsedItemHand() == mcHand) {
+                    charging = true;
+                    riptideLevel = EnchantmentHelper.getRiptide(item);
+
+                    if (riptideLevel <= 0 || player.isInWaterOrRain()) {
+                        progress =
+                                item.getUseDuration() - (player.getUseItemRemainingTicks() - partialTicks + 1.0F);
+
+                        if (progress > TridentItem.THROW_THRESHOLD_TIME) {
+                            float rotationProgress = progress - TridentItem.THROW_THRESHOLD_TIME;
+                            progress = TridentItem.THROW_THRESHOLD_TIME;
+
+                            if (riptideLevel > 0 && player.isInWaterOrRain()) {
+                                preRotation = Axis.ZP.rotationDegrees(-rotationProgress * 10.0F * riptideLevel);
+                            }
+
+                            if (VisorState.TICK_COUNT % 2 == 0) {
+                                ClientContext.inputManager.triggerHapticPulseMicroSec(
+                                        handType, 200
+                                );
+                            }
+
+                            translateX += 0.003F * (float) Math.sin(Util.getMillis());
+                        }
+                    }
+                }
+
+                if (player.isAutoSpinAttack()) {
+                    riptideLevel = 5;
+                    translateZ -= 0.15F;
+                    preRotation = Axis.ZP.rotationDegrees(
+                            (-VisorState.TICK_COUNT * 10 * riptideLevel) % 360 - partialTicks * 10.0F * riptideLevel);
+                    charging = true;
+                }
+
+                if (!charging) {
+                    translateY += 0.2F * gunAngle / 40.0F;
+                    rotation.mul(Axis.XP.rotationDegrees(gunAngle));
+                }
+
+                rotation.mul(Axis.XP.rotationDegrees(-65.0F));
+                translateZ += -0.75F + progress / 10.0F * 0.25F;
             }
         }
         return new PoseParams(preRotation, rotation, translateX, translateY, translateZ, scale);

--- a/visor-core/src/main/java/org/vmstudio/visor/core/client/render/helpers/ItemHandTransformHelper.java
+++ b/visor-core/src/main/java/org/vmstudio/visor/core/client/render/helpers/ItemHandTransformHelper.java
@@ -1,0 +1,24 @@
+package org.vmstudio.visor.core.client.render.helpers;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.math.Axis;
+import net.minecraft.world.entity.HumanoidArm;
+import org.vmstudio.visor.core.client.settings.VRClientSettings;
+
+public final class ItemHandTransformHelper {
+    private ItemHandTransformHelper() {}
+
+    public static void applyArmScaleCorrection(PoseStack poseStack) {
+        float armsScale = VRClientSettings.getPlayerModelArmsScale(); // I don't know when we can use it
+        poseStack.translate(0.0F, 0.65F, 0.0F);
+//        poseStack.scale(1.0F, armsScale, 1.0F);
+        poseStack.translate(0.0F, -0.65F, 0.0F);
+    }
+
+    public static void applyVanillaThirdPersonItemTransform(PoseStack poseStack, HumanoidArm arm) {
+        boolean isLeftHand = arm == HumanoidArm.LEFT;
+        poseStack.mulPose(Axis.XP.rotationDegrees(-90.0F));
+        poseStack.mulPose(Axis.YP.rotationDegrees(180.0F));
+        poseStack.translate((isLeftHand ? -1.0F : 1.0F) / 16.0F, 0.125F, -0.625F);
+    }
+}

--- a/visor-core/src/main/java/org/vmstudio/visor/core/client/render/player/VRPlayerRendererHandsOnly.java
+++ b/visor-core/src/main/java/org/vmstudio/visor/core/client/render/player/VRPlayerRendererHandsOnly.java
@@ -20,6 +20,7 @@ import org.vmstudio.visor.api.client.player.pose.PlayerPoseType;
 import org.vmstudio.visor.core.client.VisorState;
 import org.vmstudio.visor.core.client.player.VRClientPlayers;
 import org.vmstudio.visor.core.client.render.VRRenderState;
+import org.vmstudio.visor.core.client.render.player.model.full.VRPlayerModelFull;
 import org.vmstudio.visor.core.client.render.player.model.simple.VRPlayerModelSimple;
 import org.vmstudio.visor.core.client.render.player.model.simple.armor.VRArmorLayerSimple;
 import org.vmstudio.visor.core.client.utils.ScaleHelper;
@@ -27,6 +28,7 @@ import org.vmstudio.visor.core.client.utils.ScaleHelper;
 public class VRPlayerRendererHandsOnly extends PlayerRenderer {
     private static LayerDefinition VR_LAYER_DEFAULT;
     private static LayerDefinition VR_LAYER_SLIM;
+    private final boolean slimArms;
     static {
         createLayers();
     }
@@ -34,15 +36,16 @@ public class VRPlayerRendererHandsOnly extends PlayerRenderer {
     public static void createLayers() {
         // split arms model
         VR_LAYER_DEFAULT = LayerDefinition.create(
-                VRPlayerModelSimple.createMesh(CubeDeformation.NONE, false), 64, 64);
+                VRPlayerModelFull.createMesh(CubeDeformation.NONE, false), 64, 64);
         VR_LAYER_SLIM = LayerDefinition.create(
-                VRPlayerModelSimple.createMesh(CubeDeformation.NONE, true), 64, 64);
+                VRPlayerModelFull.createMesh(CubeDeformation.NONE, true), 64, 64);
 
     }
 
 
     public VRPlayerRendererHandsOnly(EntityRendererProvider.Context context, boolean slim) {
         super(context, slim);
+        this.slimArms = slim;
         this.model = new VRPlayerModelSimple<>(
                 slim ? VR_LAYER_SLIM.bakeRoot()
                         : VR_LAYER_DEFAULT.bakeRoot(),
@@ -106,22 +109,46 @@ public class VRPlayerRendererHandsOnly extends PlayerRenderer {
     public void renderRightHand(
             PoseStack poseStack, MultiBufferSource buffer, int combinedLight, AbstractClientPlayer player)
     {
-        this.renderHand(ControllerType.RIGHT, poseStack, buffer, combinedLight, player, this.model.rightArm,
-                this.model.rightSleeve);
+        VRPlayerModelSimple<?> model = (VRPlayerModelSimple<?>) this.model;
+        this.renderHand(
+                ControllerType.RIGHT,
+                poseStack,
+                buffer,
+                combinedLight,
+                player,
+                model.rightHand,
+                model.rightHandSleeve,
+                model.rightArm,
+                model.rightSleeve
+        );
     }
 
     @Override
     public void renderLeftHand(
             PoseStack poseStack, MultiBufferSource buffer, int combinedLight, AbstractClientPlayer player)
     {
-        this.renderHand(ControllerType.LEFT, poseStack, buffer, combinedLight, player, this.model.leftArm,
-                this.model.leftSleeve);
+        VRPlayerModelSimple<?> model = (VRPlayerModelSimple<?>) this.model;
+        this.renderHand(
+                ControllerType.LEFT,
+                poseStack,
+                buffer,
+                combinedLight,
+                player,
+                model.leftHand,
+                model.leftHandSleeve,
+                model.leftArm,
+                model.leftSleeve
+        );
     }
 
 
     private void renderHand(
             ControllerType side, PoseStack poseStack, MultiBufferSource buffer, int combinedLight,
-            AbstractClientPlayer player, ModelPart rendererArm, ModelPart rendererArmwear)
+            AbstractClientPlayer player,
+            ModelPart rendererHand,
+            ModelPart rendererHandwear,
+            ModelPart fallbackArm,
+            ModelPart fallbackArmwear)
     {
         this.setModelProperties(player);
 
@@ -131,11 +158,19 @@ public class VRPlayerRendererHandsOnly extends PlayerRenderer {
                 GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA, GlStateManager.SourceFactor.ONE,
                 GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA);
 
-        rendererArm.setPos(side == ControllerType.LEFT ? 5F : -5F, 2F, 0F);
+        ModelPart rendererArm = rendererHand != null ? rendererHand : fallbackArm;
+        ModelPart rendererArmwear = rendererHandwear != null ? rendererHandwear : fallbackArmwear;
+        boolean usingLowerHand = rendererHand != null && rendererHandwear != null;
+
+        if (!usingLowerHand) {
+            rendererArm.setPos(side == ControllerType.LEFT ? 5F : -5F, this.slimArms ? 2.0F : 2.5F, 0F);
+        }
+        rendererArm.visible = fallbackArm.visible;
         rendererArm.setRotation(0F, 0F, 0F);
         rendererArm.xScale = rendererArm.yScale = rendererArm.zScale = 1F;
 
         rendererArmwear.copyFrom(rendererArm);
+        rendererArmwear.visible = fallbackArmwear.visible;
 
         float alpha = player.getAttackStrengthScale(0.0F) * 0.75F + 0.25F;
         ResourceLocation playerSkin = this.getTextureLocation(player);

--- a/visor-core/src/main/java/org/vmstudio/visor/core/client/render/player/model/ControllerSpaceItemAnchorModel.java
+++ b/visor-core/src/main/java/org/vmstudio/visor/core/client/render/player/model/ControllerSpaceItemAnchorModel.java
@@ -1,0 +1,8 @@
+package org.vmstudio.visor.core.client.render.player.model;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.world.entity.HumanoidArm;
+
+public interface ControllerSpaceItemAnchorModel {
+    void applyLocalHandItemAnchor(HumanoidArm arm, PoseStack poseStack);
+}

--- a/visor-core/src/main/java/org/vmstudio/visor/core/client/render/player/model/full/VRPlayerModelFull.java
+++ b/visor-core/src/main/java/org/vmstudio/visor/core/client/render/player/model/full/VRPlayerModelFull.java
@@ -25,9 +25,10 @@ import net.minecraft.world.entity.LivingEntity;
 import org.vmstudio.visor.core.client.player.body.full.VRBodyFull;
 import org.vmstudio.visor.core.client.render.VRRenderState;
 import org.vmstudio.visor.core.client.render.player.model.HandModel;
+import org.vmstudio.visor.core.client.render.player.model.ControllerSpaceItemAnchorModel;
 import org.vmstudio.visor.core.client.utils.ModelUtils;
 
-public class VRPlayerModelFull<T extends LivingEntity> extends PlayerModel<T> {
+public class VRPlayerModelFull<T extends LivingEntity> extends PlayerModel<T> implements ControllerSpaceItemAnchorModel {
     public static final int LOWER_EXTENSION = 2;
     public static final int UPPER_EXTENSION = 3;
 
@@ -293,6 +294,11 @@ public class VRPlayerModelFull<T extends LivingEntity> extends PlayerModel<T> {
         poseStack.translate(side == HumanoidArm.LEFT ? -0.0625F : 0.0625F, -0.65F, 0.0F);
 
         doAttackAnim(side, poseStack);
+    }
+
+    @Override
+    public void applyLocalHandItemAnchor(HumanoidArm side, PoseStack poseStack) {
+        poseStack.translate(side == HumanoidArm.LEFT ? -0.0625F : 0.0625F, -0.65F, 0.0F);
     }
 
     protected void doAttackAnim(HumanoidArm side, PoseStack poseStack) {

--- a/visor-core/src/main/java/org/vmstudio/visor/core/client/render/player/model/simple/VRPlayerModelSimple.java
+++ b/visor-core/src/main/java/org/vmstudio/visor/core/client/render/player/model/simple/VRPlayerModelSimple.java
@@ -16,9 +16,10 @@ import org.vmstudio.visor.api.client.player.pose.PlayerPoseType;
 import org.vmstudio.visor.api.common.player.VRPose;
 import org.vmstudio.visor.core.client.player.VRClientPlayers;
 import org.vmstudio.visor.core.client.render.VRRenderState;
+import org.vmstudio.visor.core.client.render.player.model.ControllerSpaceItemAnchorModel;
 import org.vmstudio.visor.core.client.utils.ModelUtils;
 
-public class VRPlayerModelSimple<T extends LivingEntity> extends PlayerModel<T> {
+public class VRPlayerModelSimple<T extends LivingEntity> extends PlayerModel<T> implements ControllerSpaceItemAnchorModel {
 
     protected VRClientPlayer vrPlayer;
 
@@ -29,9 +30,22 @@ public class VRPlayerModelSimple<T extends LivingEntity> extends PlayerModel<T> 
     protected HumanoidArm attackArm = null;
 
 
+    public final ModelPart leftHand;
+    public final ModelPart rightHand;
+    public final ModelPart leftHandSleeve;
+    public final ModelPart rightHandSleeve;
+
+
     public VRPlayerModelSimple(ModelPart root, boolean isSlim) {
         super(root, isSlim);
-
+        this.leftHand = root.getChild("left_hand");
+        this.rightHand = root.getChild("right_hand");
+        this.leftHandSleeve = root.getChild("left_hand_sleeve");
+        this.rightHandSleeve = root.getChild("right_hand_sleeve");
+        ModelUtils.copyTextures(this.leftArm, this.leftHand);
+        ModelUtils.copyTextures(this.rightArm, this.rightHand);
+        ModelUtils.copyTextures(this.leftSleeve, this.leftHandSleeve);
+        ModelUtils.copyTextures(this.rightSleeve, this.rightHandSleeve);
     }
 
 
@@ -124,6 +138,13 @@ public class VRPlayerModelSimple<T extends LivingEntity> extends PlayerModel<T> 
         }
 
         doAttackAnim(side, poseStack);
+    }
+
+    @Override
+    public void applyLocalHandItemAnchor(HumanoidArm side, PoseStack poseStack) {
+        if (this.slim) {
+            poseStack.translate(side == HumanoidArm.LEFT ? -0.0625F : 0.0625F, 0.0F, 0.0F);
+        }
     }
 
     protected void doAttackAnim(HumanoidArm side, PoseStack poseStack) {

--- a/visor-core/src/main/java/org/vmstudio/visor/mixin/client/renderer/entity/player/layers/ItemInHandLayerMixin.java
+++ b/visor-core/src/main/java/org/vmstudio/visor/mixin/client/renderer/entity/player/layers/ItemInHandLayerMixin.java
@@ -20,6 +20,7 @@ import org.vmstudio.visor.api.common.HandType;
 import org.vmstudio.visor.core.client.ClientContext;
 import org.vmstudio.visor.core.client.player.VRClientPlayers;
 import org.vmstudio.visor.core.client.render.VRRenderState;
+import org.vmstudio.visor.core.client.render.helpers.ItemHandTransformHelper;
 import org.vmstudio.visor.core.client.settings.VRClientSettings;
 import org.vmstudio.visor.extensions.client.render.ItemInHandRendererExtension;
 
@@ -51,10 +52,7 @@ public abstract class ItemInHandLayerMixin extends RenderLayer {
             CallbackInfo ci, @Local(argsOnly = true) LivingEntity entity, @Local(argsOnly = true) PoseStack poseStack)
     {
         if (VRRenderState.isSelfModelRender(entity)) {
-            // make the item scale equal in all directions
-            poseStack.translate(0.0F, 0.65F, 0.0F);
-            poseStack.scale(1F, VRClientSettings.getPlayerModelArmsScale(), 1f);
-            poseStack.translate(0.0F, -0.65F, 0.0F);
+            ItemHandTransformHelper.applyArmScaleCorrection(poseStack);
         }
     }
 


### PR DESCRIPTION
this PR improves how items are anchored and rendered in VR + moves away from hardcoded offsets to a more dynamic-flex system

- `ControllerSpaceItemAnchorModel` interface to anchor items to the actual hand/forearm model mesh. this ensures items are positioned correctly across player models (slim/wide) and visibility modes;
- fixed VR item pose system in `VRItemPoseDefault`. reference was 0.3.0-snapshot-8;
- item transformation centralized into `ItemHandTransformHelper`. this utility helper is used in the `ItemInHandLayerMixin` and `VRHandRenderer` preventing desync between different render pipelines
- updated arm meshes in `VRPlayerRendererHandsOnly` (they look semi-similar to arms in full body type)