### PR TITLE
Fix right click staying pressed after gesture consume (#44)

### DIFF
--- a/visor-core/src/main/java/org/vmstudio/visor/core/client/tasks/types/TaskRoomConsume.java
+++ b/visor-core/src/main/java/org/vmstudio/visor/core/client/tasks/types/TaskRoomConsume.java
@@ -51,6 +51,12 @@ public class TaskRoomConsume extends VisorTask {
                 || consuming.getOrDefault(HandType.OFFHAND, false);
     }
 
+    public boolean isGestureConsuming(@NotNull InteractionHand hand) {
+        HandType handType = (hand == InteractionHand.MAIN_HAND)
+                ? HandType.MAIN : HandType.OFFHAND;
+        return consuming.getOrDefault(handType, false);
+    }
+
     @Override
     protected void onRun(LocalPlayer player) {
         LocalPlayerPose roomPose = ClientContext.localPlayer
@@ -63,6 +69,7 @@ public class TaskRoomConsume extends VisorTask {
 
         for (HandType hand : HandType.values()) {
             if(ClientContext.cursorHandler.isHandFocused(hand)){
+                consuming.put(hand, false);
                 continue;
             }
             Vector3fc handPos = calculateHandPosition(roomPose, hand);
@@ -77,6 +84,9 @@ public class TaskRoomConsume extends VisorTask {
                     ? player.getMainHandItem() : player.getOffhandItem();
 
             if (!isConsumable(foodItem)) {
+                // item finished or swapped while the hand is still at the mouth -
+                // clear the flag, otherwise releaseUsingItem stays suppressed
+                consuming.put(hand, false);
                 continue;
             }
 

--- a/visor-core/src/main/java/org/vmstudio/visor/mixin/client/MinecraftMixin.java
+++ b/visor-core/src/main/java/org/vmstudio/visor/mixin/client/MinecraftMixin.java
@@ -495,9 +495,12 @@ public abstract class MinecraftMixin implements MinecraftExtension {
 
     @WrapOperation(method = "handleKeybinds", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/multiplayer/MultiPlayerGameMode;releaseUsingItem(Lnet/minecraft/world/entity/player/Player;)V"))
     private void visor$keepConsume(MultiPlayerGameMode instance, Player player, Operation<Void> original) {
+        // only keep the item in use if THIS hand is the one gesture-consuming,
+        // so a real trigger release on the other hand (bow, shield, manual eating)
+        // is not swallowed while eating
         if (VisorState.get().isActive()
                 && TaskRoomConsume.getInstance() != null
-                && TaskRoomConsume.getInstance().isGestureConsuming()) {
+                && TaskRoomConsume.getInstance().isGestureConsuming(player.getUsedItemHand())) {
             return;
         }
         original.call(instance, player);


### PR DESCRIPTION
Follow-up to #44.

The original symptom (synthetic right-click force-pressed on the MAIN hand during gesture eating) was removed in 9ad120a, but two related cases can still reproduce "right click stays pressed":

**1. `consuming` flag can get stuck.** In `TaskRoomConsume.onRun`, when the eaten item stops being consumable (last item in the stack eaten, or item swapped) while the hand is still near the mouth, the loop hits `continue` before any reset path — `consuming[hand]` stays `true`. Same for the cursor-focused early-exit. While stuck, `isGestureConsuming()` stays `true` indefinitely, so the `releaseUsingItem` suppression in `MinecraftMixin.visor$keepConsume` never lifts.

**2. Release suppression is not hand-aware.** `visor$keepConsume` suppresses `releaseUsingItem` whenever *either* hand is gesture-consuming. If the player is gesture-eating with one hand and using an item with a real trigger press on the other hand (bow, shield, manual eating), releasing that trigger is swallowed — the item stays in use, which presents exactly as the "right click remains pressed" behavior from #44.

**Changes**
- Reset the per-hand `consuming` flag on the "not consumable" and "hand focused" early exits, so the flag lifecycle is airtight.
- Added `isGestureConsuming(InteractionHand)` and use it in `visor$keepConsume`, so release is only suppressed for the hand that is actually gesture-consuming (`player.getUsedItemHand()`).

Compiles clean on `:visor-core:compileJava` (JDK 17). I don't have a headset available on this machine, so this is verified by code-path analysis — happy to adjust if testing shows an edge I missed.
