### PR TITLE
Fix server crash from invalid network payload ID deserialization

### DIFF
--- a/visor-api/src/main/java/org/vmstudio/visor/api/common/network/VisorCorePayloadID.java
+++ b/visor-api/src/main/java/org/vmstudio/visor/api/common/network/VisorCorePayloadID.java
@@ -97,6 +97,12 @@ public enum VisorCorePayloadID {
 
     public static VisorPayloadToServer readToServer(VisorCorePayloadID payloadID,
                                              FriendlyByteBuf buffer) {
+        if (payloadID == null) {
+            VisorAPI.server().getLogger().error(
+                    "Visor: Got unexpected payload identifier on server: null"
+            );
+            return UnknownPayloadToServer.read(buffer);
+        }
         return switch (payloadID) {
             case HANDSHAKE -> HandshakePayloadToServer.read(buffer);
             case ACTIVE_HAND -> ActiveHandPayloadToServer.read(buffer);

--- a/visor-api/src/main/java/org/vmstudio/visor/api/common/network/VisorCorePayloadID.java
+++ b/visor-api/src/main/java/org/vmstudio/visor/api/common/network/VisorCorePayloadID.java
@@ -56,12 +56,21 @@ public enum VisorCorePayloadID {
     public static VisorCorePayloadID fromOrdinal(byte ordinalByte){
         // -127...127 to 0..255
         int unsignedByte = ordinalByte & 0xFF;
+        if (unsignedByte >= values().length) {
+            return null;
+        }
         return values()[unsignedByte];
     }
 
     @Environment(EnvType.CLIENT)
     public static VisorPayloadToClient readToClient(VisorCorePayloadID payloadID,
                                              FriendlyByteBuf buffer) {
+        if (payloadID == null) {
+            VisorAPI.client().getLogger().error(
+                    "Visor: Got unexpected payload identifier on client: null"
+            );
+            return UnknownPayloadToClient.read(buffer);
+        }
         return switch (payloadID) {
             case HANDSHAKE -> HandshakePayloadToClient.read(buffer);
             case SERVER_SETTINGS -> SettingsPayloadToClient.read(buffer);

--- a/visor-core/src/main/java/org/vmstudio/visor/core/server/network/ServerNetworking.java
+++ b/visor-core/src/main/java/org/vmstudio/visor/core/server/network/ServerNetworking.java
@@ -44,7 +44,7 @@ public class ServerNetworking {
                 VisorNetwork.CORE_NETWORK_VERSION
         ).toServer(
                 (id, buffer)->{
-                    VisorCorePayloadID payloadId = VisorCorePayloadID.values()[id];
+                    VisorCorePayloadID payloadId = VisorCorePayloadID.fromOrdinal(id);
                     return VisorCorePayloadID.readToServer(payloadId, buffer);
                 },
                 ServerPacketHandler::handlePacket


### PR DESCRIPTION
Fixed `ArrayIndexOutOfBoundsException` and `NullPointerException` vulnerabilities during packet deserialization in `ServerNetworking` and `VisorCorePayloadID`. Out-of-bounds or unknown payload IDs received over the network now gracefully log a warning and return unknown payload fallback instances.